### PR TITLE
Develop/simple foc

### DIFF
--- a/main/AS5048/example/main.cpp
+++ b/main/AS5048/example/main.cpp
@@ -1,0 +1,323 @@
+#include <stdio.h>
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "freertos/queue.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
+#include "esp_system.h"
+
+// SPI & IMU
+#include "SPICREATE.hpp"
+#include "ICM42688.hpp" // ユーザ定義IMUライブラリ
+#include "gptimer.hpp"
+#include "SimpleQuat.hpp"
+
+// SDMMC Logger (バッファリング対応版を使用してください)
+#include "SdmmcLogger.hpp"
+
+#define TIMER_RESOLUTION_HZ (1000 * 1000) // 1MHz
+#define TIMER_ALARM_COUNT (1000)          // 1000ticks = 1ms(=1kHz)
+
+// // AS5048AのCSピン (2個分)
+// #define CS_AS5048_1 GPIO_NUM_7
+// #define CS_AS5048_2 GPIO_NUM_39
+
+// センサデータをキューでやりとりするための構造体
+typedef struct
+{
+    int16_t sensor[8]; // 0..5: ICM42688 (Ax,Ay,Az, Gx,Gy,Gz), 6..7: AS5048A角度用
+    uint64_t timestamp_us;
+} sensor_data_t;
+
+// グローバル変数
+static QueueHandle_t g_sensorQueue = nullptr; // センサー生データ用キュー
+static SPICreate g_spi;                       // SPIクラス
+static ICM g_icm;                             // IMU
+static SdmmcLogger g_sdCard;                  // SDカードロガー
+static GPTimer g_gpt;                         // GPTimer
+
+// // AS5048A用デバイスハンドル
+// static int g_as5048_handle1 = -1;
+// static int g_as5048_handle2 = -1;
+
+// 角速度スケーリング係数 (ICM42688 ±2000dps相当)
+static constexpr float GYRO_SCALE_2000DPS = (1.0f / 16.4f) * (3.1415926535f / 180.0f);
+
+//---------------------------------------------------------------------------------
+// AS5048A から角度を読む簡易関数
+//   - 2トランザクション方式で0xFFFFを連続送信し、2回目の返り値下位14bitがangle
+//---------------------------------------------------------------------------------
+static uint16_t readAS5048Angle(int deviceHandle)
+{
+    // 送受バッファ
+    uint16_t tx = 0xFFFF;
+    uint16_t rx = 0;
+
+    // 1回目(ダミー読み出し)
+    {
+        spi_transaction_t trans = {};
+        trans.length = 16; // 16ビット送受信
+        trans.tx_buffer = &tx;
+        trans.rx_buffer = &rx;
+        g_spi.pollTransmit(&trans, deviceHandle);
+        // 1回目のrxは無視(前回コマンド結果なので)
+    }
+
+    // 2回目(実際の角度データが返る)
+    {
+        spi_transaction_t trans = {};
+        trans.length = 16;
+        trans.tx_buffer = &tx;
+        trans.rx_buffer = &rx;
+        g_spi.pollTransmit(&trans, deviceHandle);
+    }
+
+    // 下位14bitが角度値
+    uint16_t angle14 = rx & 0x3FFF;
+    return angle14;
+}
+
+// 割り込みコールバック(1kHz)
+static bool IRAM_ATTR sensorTimerCallback(gptimer_handle_t timer,
+                                          const gptimer_alarm_event_data_t *edata,
+                                          void *user_ctx)
+{
+    // IMUからセンサ値を取得
+    sensor_data_t sdata;
+    int16_t sensor[6] = {0};
+    g_icm.Get(sensor);
+
+    for (int i = 0; i < 6; i++)
+    {
+        sdata.sensor[i] = sensor[i];
+    }
+
+    // // AS5048A x 2個の角度読み取り
+    // // (注) ISR内でSPI処理するので、できれば最低限の処理に留める
+    // sdata.sensor[6] = (int16_t)readAS5048Angle(g_as5048_handle1);
+    // sdata.sensor[7] = (int16_t)readAS5048Angle(g_as5048_handle2);
+
+    // タイムスタンプ(μs)
+    sdata.timestamp_us = (uint64_t)esp_timer_get_time();
+
+    // キューへ送る
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    xQueueSendFromISR(g_sensorQueue, &sdata, &xHigherPriorityTaskWoken);
+
+    return (xHigherPriorityTaskWoken == pdTRUE);
+}
+
+// -----------------------------
+// センサー側タスク
+// -----------------------------
+static void sensorTask(void *args)
+{
+    // 1. SPI初期化
+    bool ret = g_spi.begin(
+        SPI2_HOST,
+        (gpio_num_t)6,   // SCLK
+        (gpio_num_t)4,   // MISO
+        (gpio_num_t)5,   // MOSI
+        40 * 1000 * 1000 // 8MHz
+    );
+    if (!ret)
+    {
+        ESP_LOGE("sensorTask", "SPI begin failed");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    // 2. ICM42688初期化
+    g_icm.begin(&g_spi, (gpio_num_t)40, 24 * 1000 * 1000);
+
+    // // 2.5. AS5048Aデバイス追加 (CS=7,39)
+    // {
+    //     spi_device_interface_config_t devcfg = {};
+    //     devcfg.cs_ena_pretrans = 0;
+    //     devcfg.clock_speed_hz = 8 * 1000 * 1000; // 2MHz
+    //     devcfg.mode = 1;                         // CPOL=1/CPHA=1
+    //     devcfg.queue_size = 1;
+    //     g_as5048_handle1 = g_spi.addDevice(&devcfg, CS_AS5048_1);
+    //     ESP_LOGI("as5048", "deviceHandle %d", g_as5048_handle1);
+    //     if (g_as5048_handle1 == 0)
+    //     {
+    //         ESP_LOGE("sensorTask", "AS5048_1 addDevice failed");
+    //     }
+
+    //     g_as5048_handle2 = g_spi.addDevice(&devcfg, CS_AS5048_2);
+    //     if (g_as5048_handle2 == 0)
+    //     {
+    //         ESP_LOGE("sensorTask", "AS5048_2 addDevice failed");
+    //     }
+    //     ESP_LOGI("as5048", "deviceHandle %d", g_as5048_handle2);
+    // }
+
+    // 3. キューを作成 (深さは必要に応じて調整)
+    g_sensorQueue = xQueueCreate(512, sizeof(sensor_data_t));
+    if (!g_sensorQueue)
+    {
+        ESP_LOGE("sensorTask", "Failed to create sensor queue");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    // 4. GPTimer初期化 (1MHz, アラーム=1000 → 1kHz)
+    if (!g_gpt.init(TIMER_RESOLUTION_HZ, TIMER_ALARM_COUNT))
+    {
+        ESP_LOGE("sensorTask", "Failed to init GPTimer");
+        vTaskDelete(NULL);
+        return;
+    }
+    // コールバック登録 (ISRでセンサー読み込み & キュー送信)
+    if (!g_gpt.registerCallback(sensorTimerCallback))
+    {
+        ESP_LOGE("sensorTask", "Failed to register GPTimer callback");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    // 5. タイマー開始
+    if (!g_gpt.start())
+    {
+        ESP_LOGE("sensorTask", "Failed to start GPTimer");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    ESP_LOGI("sensorTask", "Sensor reading started (1kHz by GPTimer)");
+
+    // 割り込みが動いている間、ここでは特にすることがない
+    // 必要に応じて他の処理を入れてもよい
+    while (true)
+    {
+        // 1秒に1回程度ログを出すなど
+        vTaskDelay(pdMS_TO_TICKS(1000));
+        ESP_LOGD("sensorTask", "Sensor task alive...");
+    }
+
+    vTaskDelete(NULL);
+}
+
+// -----------------------------
+// ロギングタスク
+// -----------------------------
+static void loggingTask(void *args)
+{
+    // 1. SDカード初期化 (バッファリング対応)
+    //    例: HighSpeed = false, mountPoint="/sdcard", logFile="/sdcard/gyro_log.csv"
+    bool useHighSpeed = false;
+    if (!g_sdCard.begin(useHighSpeed, "/sdcard", "/sdcard/gyro_log.csv"))
+    {
+        ESP_LOGE("loggingTask", "Failed to mount or open log file.");
+        vTaskDelete(NULL);
+        return;
+    }
+    ESP_LOGI("loggingTask", "SD card initialized");
+
+    // 2. クォータニオン演算用インスタンス (サンプリング周期=1kHz → 0.001f)
+    SimpleQuat quat(GYRO_SCALE_2000DPS, 0.001f);
+
+    // -----------------------------
+    // 2-1. キャリブレーション
+    // -----------------------------
+    ESP_LOGI("loggingTask", "Start gyro bias calibration for 60sec...");
+    const int sample_count = 1000 * 5; // 60秒
+    float sumX = 0.0f, sumY = 0.0f, sumZ = 0.0f;
+    int countSample = 0;
+
+    for (int i = 0; i < sample_count; i++)
+    {
+        sensor_data_t data;
+        // キューからデータを取り出す (60秒間は連続で待つ)
+        if (xQueueReceive(g_sensorQueue, &data, portMAX_DELAY) == pdTRUE)
+        {
+            sumX += data.sensor[3];
+            sumY += data.sensor[4];
+            sumZ += data.sensor[5];
+            countSample++;
+        }
+    }
+
+    float offsetX = (countSample > 0) ? (sumX / countSample) : 0.0f;
+    float offsetY = (countSample > 0) ? (sumY / countSample) : 0.0f;
+    float offsetZ = (countSample > 0) ? (sumZ / countSample) : 0.0f;
+    quat.setGyroBias(offsetX, offsetY, offsetZ);
+
+    ESP_LOGI("loggingTask", "Calibration done! Gyro bias = (%.2f, %.2f, %.2f)",
+             offsetX, offsetY, offsetZ);
+
+    // -----------------------------
+    // 2-2. 通常ロギング
+    // -----------------------------
+    uint32_t printcount = 0; // コンソール出力用カウンタ
+    while (true)
+    {
+        sensor_data_t recvData;
+        // センサデータを待つ
+        if (xQueueReceive(g_sensorQueue, &recvData, portMAX_DELAY) == pdTRUE)
+        {
+            // クォータニオン更新(角速度=recvData.sensor[3..5])
+            quat.updateFromRawGyro(&recvData.sensor[3]);
+
+            // オイラー角計算(ラジアン)
+            float euler[3];
+            quat.getEulerRad(euler);
+
+            // 度数法に変換
+            float roll_deg = euler[0] * (180.0f / 3.1415926535f);
+            float pitch_deg = euler[1] * (180.0f / 3.1415926535f);
+            float yaw_deg = euler[2] * (180.0f / 3.1415926535f);
+
+            // // AS5048A角度 (2ch)
+            // // 下位14ビットなので、0〜16383 (1LSB=360/16384=約0.0219度)
+            // int16_t angle_raw_1 = recvData.sensor[6];
+            // int16_t angle_raw_2 = recvData.sensor[7];
+            // float angle_deg_1 = (angle_raw_1 * 360.0f) / 16384.0f;
+            // float angle_deg_2 = (angle_raw_2 * 360.0f) / 16384.0f;
+
+            // ログファイルへ書き込み
+            g_sdCard.writeLog(
+                recvData.timestamp_us,
+                recvData.sensor[3],
+                recvData.sensor[4],
+                recvData.sensor[5],
+                roll_deg, pitch_deg, yaw_deg);
+
+            // 100回に1回コンソールへ
+            if (printcount++ == 1000)
+            {
+                g_sdCard.flush();
+                ESP_LOGI("loggingTask",
+                         "[%.2f ms] GYRO=(%d,%d,%d), EULER=(%.2f,%.2f,%.2f), ",
+                         recvData.timestamp_us / 1000.0,
+                         recvData.sensor[3], recvData.sensor[4], recvData.sensor[5],
+                         roll_deg, pitch_deg, yaw_deg);
+                printcount = 0;
+            }
+        }
+    }
+
+    // (実際にタスクが終了する場合はファイルをクローズ)
+    // g_sdCard.end();
+    vTaskDelete(NULL);
+}
+
+// -----------------------------
+// メイン (タスク生成)
+// -----------------------------
+extern "C" void app_main(void)
+{
+    // センサータスク作成
+    xTaskCreatePinnedToCore(sensorTask, "sensorTask", 4096, NULL, 5, NULL, 1);
+    // ロギングタスク作成
+    xTaskCreatePinnedToCore(loggingTask, "loggingTask", 4096, NULL, 5, NULL, 1);
+
+    // メインタスクは何もしない場合
+    // (不要なら vTaskDelete(NULL) で自滅しても可)
+    while (1)
+    {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}

--- a/main/CAN/73CanConfig.hpp
+++ b/main/CAN/73CanConfig.hpp
@@ -19,11 +19,12 @@ struct CanRxFrame
 // 送信基板ID(上位3bit)の定義
 enum class BoardID : uint8_t
 {
-    COMMUNICATION = 0b000, // 通信基板
-    PARA = 0b001,          // 開放基板
-    POWER = 0b010,         // 電源管理基板
-    GIMBAL = 0b100,        // ジンバル基板
-    CAMERA = 0b100,        // カメラ基板
+    COM = 0b000,     // 通信基板
+    PARA = 0b001,    // 開放基板
+    POWER = 0b010,   // 電源管理基板
+    GIMBAL = 0b011,  // ジンバル基板
+    CAMERA = 0b100,  // カメラ基板
+    UNKNOWN = 0b111, // 不明
 };
 
 // 通信内容ID(下位8bit)の定義

--- a/main/CAN/73CanConfig.hpp
+++ b/main/CAN/73CanConfig.hpp
@@ -3,19 +3,6 @@
 
 #include <cstdint>
 
-/**
- * @brief 受信データを受け取る際の構造体
- * @param id: 11bit標準ID
- * @param dlc: データ長
- * @param data: 受信データ
- */
-struct CanRxFrame
-{
-    uint16_t id; ///< 11bit標準ID
-    uint8_t dlc;
-    uint8_t data[8];
-};
-
 // 送信基板ID(上位3bit)の定義
 enum class BoardID : uint8_t
 {
@@ -36,6 +23,19 @@ enum class ContentID : uint8_t
     LIFTOFF_APOGEE = 0x03,  // 離床 or 頂点検知通知
     VOLTAGE = 0x04,         // 電圧送信
     QUATERNION = 0x05,      // クオータニオン送信
+};
+
+/**
+ * @brief 受信データを受け取る際の構造体
+ * @param dlc: データ長
+ * @param data: 受信データ
+ */
+struct CanRxFrame
+{
+    BoardID sender_board_id;
+    ContentID content_id;
+    uint8_t dlc;
+    uint8_t data[8];
 };
 
 // モード遷移コマンド(通信内容ID:0x00)

--- a/main/CAN/73CanConfig.hpp
+++ b/main/CAN/73CanConfig.hpp
@@ -1,0 +1,63 @@
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * @brief 受信データを受け取る際の構造体
+ * @param id: 11bit標準ID
+ * @param dlc: データ長
+ * @param data: 受信データ
+ */
+struct CanRxFrame
+{
+    uint16_t id; ///< 11bit標準ID
+    uint8_t dlc;
+    uint8_t data[8];
+};
+
+// 送信基板ID(上位3bit)の定義
+enum class BoardID : uint8_t
+{
+    COMMUNICATION = 0b000, // 通信基板
+    PARA = 0b001,          // 開放基板
+    POWER = 0b010,         // 電源管理基板
+    GIMBAL = 0b100,        // ジンバル基板
+    CAMERA = 0b100,        // カメラ基板
+};
+
+// 通信内容ID(下位8bit)の定義
+enum class ContentID : uint8_t
+{
+    MODE_TRANSITION = 0x00, // モード遷移コマンド
+    KAIHOU_COMMAND = 0x01,  // 開放機構動作コマンド
+    BOARD_STATE = 0x02,     // 基板状態(要求 or 送信)
+    LIFTOFF_APOGEE = 0x03,  // 離床 or 頂点検知通知
+    VOLTAGE = 0x04,         // 電圧送信
+    QUATERNION = 0x05,      // クオータニオン送信
+};
+
+// モード遷移コマンド(通信内容ID:0x00)
+enum class ModeCommand : uint8_t
+{
+    START = 's',       // "Start Mode"
+    PREPARATION = 'p', // "Preparation Mode"
+    LOGGING = 'l',     // "Logging Mode"
+};
+
+// 開放機構動作コマンド(通信内容ID:0x01)
+enum class ServoCommand : uint8_t
+{
+    CLOSE_SERVO = 'c',       // サーボクローズ
+    ANGLE_MINUS_1 = 'n',     // パラシュートオープンの角度を1度小さくする(Startモード時のみ)
+    ANGLE_PLUS_1 = 'm',      // パラシュートオープンの角度を1度大きくする(Startモード時のみ)
+    CLOSE_ANGLE_PLUS = 'q',  // パラシュートクローズの角度を1度大きくする(Startモード時のみ)
+    CLOSE_ANGLE_MINUS = 'r', // パラシュートクローズの角度を1度小さくする(Startモード時のみ)
+};
+
+// 離床 or 頂点検知通知(通信内容ID:0x03)
+enum class ParauStatus : uint8_t
+{
+    APOGEE_DETECTED = 'y', // 頂点検知通知
+    LIFTOFF_DETECT = 'x',  // 離床検知通知
+};

--- a/main/CAN/CanComm.cpp
+++ b/main/CAN/CanComm.cpp
@@ -1,6 +1,4 @@
-#pragma once
-
-#include "CanComm.h"
+#include "CanComm.hpp"
 #include <cstring>
 
 //---------------------------------------
@@ -22,14 +20,14 @@ void CanComm::parseStdId(uint16_t sid, BoardID &bOut, ContentID &cOut)
 
 //---------------------------------------
 // コンストラクタ
-//---------------------------------------
+//---------------------------------------a
 CanComm::CanComm(BoardID self_board_id,
                  int tx_gpio,
                  int rx_gpio,
                  BoardID filter_board1,
                  BoardID filter_board2,
                  uint32_t tx_queue_len,
-                 uint32_t rx_queue_len, )
+                 uint32_t rx_queue_len)
     : self_board_id_(self_board_id),
       fb1_(filter_board1),
       fb2_(filter_board2),
@@ -47,8 +45,7 @@ CanComm::CanComm(BoardID self_board_id,
         .rx_queue_len = rx_queue_len,
         .alerts_enabled = TWAI_ALERT_RX_DATA | TWAI_ALERT_BUS_OFF,
         .clkout_divider = 0,
-        .intr_flags = ESP_INTR_FLAG_LOWMED,
-        .sleep_allow_pd = 0};
+        .intr_flags = ESP_INTR_FLAG_LOWMED};
 
     t_config_ = TWAI_TIMING_CONFIG_500KBITS();
 
@@ -196,7 +193,7 @@ void CanComm::setupFilter()
     {
         f_config_.single_filter = false;
 
-        auto encodeBoard = [&](CanBoardID b)
+        auto encodeBoard = [&](BoardID b)
         {
             return static_cast<uint16_t>((static_cast<uint8_t>(b) & 0x07) << 8);
         };

--- a/main/CAN/CanComm.cpp
+++ b/main/CAN/CanComm.cpp
@@ -1,0 +1,227 @@
+#pragma once
+
+#include "CanComm.h"
+#include <cstring>
+
+//---------------------------------------
+// ID変換
+//---------------------------------------
+uint16_t CanComm::makeStdId(BoardID board, ContentID content)
+{
+    uint16_t b = static_cast<uint8_t>(board) & 0x07;
+    uint16_t c = static_cast<uint8_t>(content);
+    return (b << 8) | c; // 3bit + 8bit = 11bit
+}
+void CanComm::parseStdId(uint16_t sid, BoardID &bOut, ContentID &cOut)
+{
+    uint8_t b = (sid >> 8) & 0x07;
+    uint8_t c = sid & 0xFF;
+    bOut = static_cast<BoardID>(b);
+    cOut = static_cast<ContentID>(c);
+}
+
+//---------------------------------------
+// コンストラクタ
+//---------------------------------------
+CanComm::CanComm(BoardID self_board_id,
+                 int tx_gpio,
+                 int rx_gpio,
+                 BoardID filter_board1,
+                 BoardID filter_board2,
+                 uint32_t tx_queue_len,
+                 uint32_t rx_queue_len, )
+    : self_board_id_(self_board_id),
+      fb1_(filter_board1),
+      fb2_(filter_board2),
+      driver_installed_(false)
+{
+    // config初期化
+    g_config_ = {
+        .controller_id = 0,
+        .mode = TWAI_MODE_NORMAL,
+        .tx_io = (gpio_num_t)tx_gpio,
+        .rx_io = (gpio_num_t)rx_gpio,
+        .clkout_io = GPIO_NUM_NC,
+        .bus_off_io = GPIO_NUM_NC,
+        .tx_queue_len = tx_queue_len,
+        .rx_queue_len = rx_queue_len,
+        .alerts_enabled = TWAI_ALERT_RX_DATA | TWAI_ALERT_BUS_OFF,
+        .clkout_divider = 0,
+        .intr_flags = ESP_INTR_FLAG_LOWMED,
+        .sleep_allow_pd = 0};
+
+    t_config_ = TWAI_TIMING_CONFIG_500KBITS();
+
+    f_config_ = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+}
+
+esp_err_t CanComm::begin()
+{
+    if (driver_installed_)
+    {
+        return ESP_ERR_INVALID_STATE;
+    }
+    // フィルタ設定を反映
+    setupFilter();
+
+    // ドライバインストール
+    esp_err_t err = twai_driver_install(&g_config_, &t_config_, &f_config_);
+    if (err != ESP_OK)
+    {
+        return err;
+    }
+    // スタート
+    err = twai_start();
+    if (err == ESP_OK)
+    {
+        driver_installed_ = true;
+    }
+    else
+    {
+        twai_driver_uninstall();
+    }
+    return err;
+}
+
+//---------------------------------------
+// send: 自BoardID <<8 | content
+//---------------------------------------
+esp_err_t CanComm::send(ContentID content, const uint8_t *data, size_t len)
+{
+    if (!driver_installed_)
+    {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (len > 8)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+    uint16_t sid = makeStdId(self_board_id_, content);
+
+    twai_message_t tx_msg = {};
+    tx_msg.extd = 0; // standard
+    tx_msg.rtr = 0;  // data frame
+    tx_msg.identifier = sid;
+    tx_msg.data_length_code = len;
+    if (data && len > 0)
+    {
+        memcpy(tx_msg.data, data, len);
+    }
+
+    return twai_transmit(&tx_msg, pdMS_TO_TICKS(100));
+}
+
+//---------------------------------------
+// readFrameNoWait
+//---------------------------------------
+esp_err_t CanComm::readFrameNoWait(CanRxFrame &outFrame)
+{
+    if (!driver_installed_)
+    {
+        return ESP_ERR_INVALID_STATE;
+    }
+    twai_message_t rx_msg;
+    esp_err_t err = twai_receive(&rx_msg, 0);
+    if (err != ESP_OK)
+    {
+        return err; // ESP_ERR_TIMEOUTなど
+    }
+    if (rx_msg.extd)
+    {
+        // 拡張IDは未対応
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    parseStdId(rx_msg.identifier, outFrame.sender_board_id, outFrame.content_id);
+    outFrame.dlc = rx_msg.data_length_code;
+    memcpy(outFrame.data, rx_msg.data, rx_msg.data_length_code);
+    for (int i = rx_msg.data_length_code; i < 8; i++)
+    {
+        outFrame.data[i] = 0;
+    }
+    return ESP_OK;
+}
+
+//---------------------------------------
+// バスオフリカバリ
+//---------------------------------------
+esp_err_t CanComm::recover()
+{
+    return twai_initiate_recovery();
+}
+
+//---------------------------------------
+// setupFilter(): fb1_, fb2_ の状況で切替
+//---------------------------------------
+void CanComm::setupFilter()
+{
+    // ===============
+    // 0枚指定 → accept all
+    // ===============
+    if (fb1_ == BoardID::UNKNOWN && fb2_ == BoardID::UNKNOWN)
+    {
+        f_config_ = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+        return;
+    }
+
+    // ===============
+    // 1枚指定 → single filter
+    // ===============
+    if (fb1_ != BoardID::UNKNOWN && fb2_ == BoardID::UNKNOWN)
+    {
+        // Standard Filter (全11bit中 上位3bitだけ厳密に一致, 下位8bit無視)
+        f_config_.single_filter = true;
+
+        // 11bit上位3bitが fb1_ に一致するように code と mask を作る
+        uint16_t boardSid = (static_cast<uint8_t>(fb1_) & 0x07) << 8;
+
+        // SingleFilterMode のビット配置:
+        //  - bits[0..10] = SFF ID
+        //  - bits[11..12] = RTR,IDE
+        //  → acceptance_code は下位11bitにIDを詰める
+        // ここでは下位8bitを無視するので mask でそこを0に
+        uint16_t maskVal = 0x700; // bits[10..8]だけ見る -> 0b11100000000
+        uint32_t code = (boardSid & 0x7FF) << 21;
+        uint32_t mask = (maskVal & 0x7FF) << 21;
+
+        f_config_.acceptance_code = code;
+        f_config_.acceptance_mask = mask;
+        return;
+    }
+
+    // ===============
+    // 2枚指定 → dual filter
+    // ===============
+    if (fb1_ != BoardID::UNKNOWN && fb2_ != BoardID::UNKNOWN)
+    {
+        f_config_.single_filter = false;
+
+        auto encodeBoard = [&](CanBoardID b)
+        {
+            return static_cast<uint16_t>((static_cast<uint8_t>(b) & 0x07) << 8);
+        };
+        uint16_t sidA = encodeBoard(fb1_);
+        uint16_t sidB = encodeBoard(fb2_);
+
+        // DualFilterMode:
+        //  - bits[29..19] = Filter A for SFF
+        //  - bits[13..3]  = Filter B for SFF
+        //  - mask も同様
+        uint16_t maskVal = 0x700; // 上位3bitだけ見る
+
+        uint32_t codeA = (sidA & 0x7FF) << 19;
+        uint32_t codeB = (sidB & 0x7FF) << 3;
+        uint32_t code = codeA | codeB;
+
+        uint32_t maskA = (maskVal & 0x7FF) << 19;
+        uint32_t maskB = (maskVal & 0x7FF) << 3;
+        uint32_t mask = maskA | maskB;
+
+        f_config_.acceptance_code = code;
+        f_config_.acceptance_mask = mask;
+        return;
+    }
+
+    // 上記以外のケース
+    f_config_ = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+}

--- a/main/CAN/CanComm.hpp
+++ b/main/CAN/CanComm.hpp
@@ -1,0 +1,87 @@
+#include "driver/twai.h"
+#include "73CANConfig.hpp"
+
+/**
+ * @brief CAN (TWAI) 通信クラス
+ *
+ * - コンストラクタで自分の送信BoardID (self_board_id) を指定
+ * - フィルタ用に受信 boardID を最大2つまで指定可能
+ *    - 全て受け入れ (filter_board1=UNKNOWN, filter_board2=UNKNOWN) → AcceptAll
+ *    - 特定の１基板からのみ受信 (filter_board1だけ有効) → Single Filter Mode
+ *    - 特定の２基板からのみ受信 → Dual Filter Mode
+ * - begin()/end() でドライバをインストール/アンインストール
+ * - send() では contentID と data を指定して送信
+ * - readFrameNoWait() は非ブロッキング受信(呼び出しじにRX FIFOが空ならば即座に返る)
+ * - recover() でCANバス復帰を試みる
+ */
+class CanComm
+{
+public:
+    /**
+     * @param self_board_id     自分の送信BoardID
+     * @param tx_gpio           TWAI TXピン
+     * @param rx_gpio           TWAI RXピン
+     * @param filter_board1(option)     1つ目のフィルタ対象BoardID (UNKNOWN=指定なし)
+     * @param filter_board2(option)     2つ目 (UNKNOWN=指定なし)
+     * @param tx_queue_len (default=10) 送信キュー長
+     * @param rx_queue_len (default=10) 受信キュー長
+     */
+    CanComm(BoardID self_board_id,
+            int tx_gpio,
+            int rx_gpio,
+            BoardID filter_board1 = CanBoardID::UNKNOWN,
+            BoardID filter_board2 = CanBoardID::UNKNOWN,
+            uint32_t tx_queue_len = 10,
+            uint32_t rx_queue_len = 10, );
+
+    /**
+     * @brief ドライバインストール & スタート
+     */
+    esp_err_t begin();
+
+    /**
+     * @brief ドライバストップ & アンインストール
+     */
+    esp_err_t end();
+
+    /**
+     * @brief 送信 (BoardIDはコンストラクタ指定)
+     */
+    esp_err_t send(ContentID content, const uint8_t *data, size_t len);
+
+    /**
+     * @brief 非ブロッキング受信
+     * @return
+     *  - ESP_OK: 1フレーム取り出し
+     *  - ESP_ERR_TIMEOUT: キュー空
+     *  - ESP_ERR_NOT_SUPPORTED: 拡張ID受信 etc
+     *  - ESP_ERR_INVALID_STATE: ドライバ未開始
+     */
+    esp_err_t readFrameNoWait(/*out*/ CanRxFrame &outFrame);
+
+    /**
+     * @brief バスオフリカバリ開始
+     */
+    esp_err_t recover();
+
+private:
+    BoardID self_board_id_;
+
+    // フィルタ対象 (最大2つ)
+    BoardID fb1_;
+    BoardID fb2_;
+
+    twai_general_config_t g_config_;
+    twai_timing_config_t t_config_;
+    twai_filter_config_t f_config_;
+
+    bool driver_installed_;
+
+private:
+    // ID変換
+    static uint16_t makeStdId(BoardID board, ContentID content);
+    static void parseStdId(uint16_t sid, BoardID &bOut, ContentID &cOut);
+
+    // フィルタ設定 (内部で呼ぶ)
+    void setupFilter();
+};

--- a/main/CAN/CanComm.hpp
+++ b/main/CAN/CanComm.hpp
@@ -29,10 +29,10 @@ public:
     CanComm(BoardID self_board_id,
             int tx_gpio,
             int rx_gpio,
-            BoardID filter_board1 = CanBoardID::UNKNOWN,
-            BoardID filter_board2 = CanBoardID::UNKNOWN,
+            BoardID filter_board1 = BoardID::UNKNOWN,
+            BoardID filter_board2 = BoardID::UNKNOWN,
             uint32_t tx_queue_len = 10,
-            uint32_t rx_queue_len = 10, );
+            uint32_t rx_queue_len = 10);
 
     /**
      * @brief ドライバインストール & スタート

--- a/main/CAN/example/main.cpp
+++ b/main/CAN/example/main.cpp
@@ -58,9 +58,10 @@ extern "C" void app_main(void)
                     if (e == ESP_OK)
                     {
                         // 受信成功
-                        printf("[MAIN] ID=%d, dlc=%d\n",
-                               (int)rx.id,
-                               (int)rx.dlc);
+                        printf("[MAIN] Rx from Board=%d, Content=0x%02X, dlc=%d\n",
+                               (int)rx.sender_board_id,
+                               (int)rx.content_id,
+                               rx.dlc);
                     }
                     else if (e == ESP_ERR_TIMEOUT)
                     {

--- a/main/CAN/example/main.cpp
+++ b/main/CAN/example/main.cpp
@@ -58,10 +58,9 @@ extern "C" void app_main(void)
                     if (e == ESP_OK)
                     {
                         // 受信成功
-                        printf("[MAIN] Rx from Board=%d, Content=0x%02X, dlc=%d\n",
-                               (int)rx.sender_board_id,
-                               (int)rx.content_id,
-                               rx.dlc);
+                        printf("[MAIN] ID=%d, dlc=%d\n",
+                               (int)rx.id,
+                               (int)rx.dlc);
                     }
                     else if (e == ESP_ERR_TIMEOUT)
                     {

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -3,6 +3,7 @@ idf_component_register(
          "svpwm/esp_svpwm.c" 
          "foc/esp_foc.c"
          "SPICREATE/SPICREATE.cpp"
+         "CAN/CanComm.cpp"
     INCLUDE_DIRS "svpwm" 
                  "foc"
                  "SPICREATE"
@@ -10,5 +11,6 @@ idf_component_register(
                  "gptimer"
                  "Quaternion"
                  "SdmmcLogger"
+                 "CAN"
     REQUIRES driver esp_timer log sdmmc fatfs
 )

--- a/main/SPICREATE/SPICREATE.cpp
+++ b/main/SPICREATE/SPICREATE.cpp
@@ -43,7 +43,7 @@ int SPICreate::addDevice(spi_device_interface_config_t *if_cfg, int cs)
 
     if_cfg->spics_io_num = cs;
 
-    if (deviceNum > 2)
+    if (deviceNum > 4)
     {
         ESP_LOGE("SPICreate", "Device number over");
         return 0; // handle[0..2]までしか用意していないので

--- a/main/SPICREATE/SPICREATE.hpp
+++ b/main/SPICREATE/SPICREATE.hpp
@@ -11,11 +11,11 @@
 class SPICreate
 {
     spi_bus_config_t bus_cfg = {};
-    spi_device_handle_t handle[3];
+    spi_device_handle_t handle[4];
     int deviceNum{0};
     spi_host_device_t host = SPI2_HOST;
-    uint8_t mode = 3; // must be 1 or 3
-    int max_size{4094};      // default size
+    uint8_t mode = 3;   // must be 1 or 3
+    int max_size{4094}; // default size
     uint32_t frequency{SPI_MASTER_FREQ_8M};
 
     std::deque<spi_transaction_t> transactions;
@@ -23,9 +23,9 @@ class SPICreate
 
 public:
     bool begin(spi_host_device_t host_in = SPI2_HOST,
-               int sck = -1, 
-               int miso = -1, 
-               int mosi = -1, 
+               int sck = -1,
+               int miso = -1,
+               int mosi = -1,
                uint32_t f = SPI_MASTER_FREQ_8M);
 
     bool end();

--- a/main/app_main.cpp
+++ b/main/app_main.cpp
@@ -1,95 +1,332 @@
 #include <stdio.h>
+#include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "freertos/queue.h"
+#include "driver/gpio.h"
+#include "esp_timer.h"
+#include "esp_system.h"
 
-#include "CanComm.hpp"
+// SPI & IMU
+#include "SPICREATE.hpp"
+#include "ICM42688.hpp"
+#include "gptimer.hpp"
+#include "SimpleQuat.hpp"
 
-extern "C" void app_main(void)
+// SDMMC Logger
+#include "SdmmcLogger.hpp"
+
+// ------------------ ここから SimpleFOC 追加 ------------------
+#include "esp_simplefoc.h"
+
+// [例] 2つのBLDCモータを定義（極数やPWMピンは実際の配線に応じて設定してください）
+// モータ1
+static BLDCMotor motor1 = BLDCMotor(7); // 極数=7極ペア (14極モータ) の例
+static BLDCDriver3PWM driver1 = BLDCDriver3PWM(38, 45, 48);
+
+// モータ2
+static BLDCMotor motor2 = BLDCMotor(7); // 同様に7極ペア
+static BLDCDriver3PWM driver2 = BLDCDriver3PWM(10, 11, 12);
+// ------------------------------------------------------------
+
+#define TIMER_RESOLUTION_HZ (1000 * 1000) // 1MHz
+#define TIMER_ALARM_COUNT (1000)          // 1000ticks = 1ms(=1kHz)
+
+// センサデータをキューでやりとりするための構造体
+typedef struct
 {
-    // 例: 自分は GIMBAL(0b011) という基板として動作
-    //     フィルタで1枚だけ: COM を受信したい
-    //       → single filter
-    //  (filter_board2=UNKNOWN(0xFF))
-    //  + RX_DATAアラートを有効化
-    CanComm can(
-        /*self_board_id=*/BoardID::GIMBAL,
-        /*tx_gpio=*/21,
-        /*rx_gpio=*/22,
-        /*filter_board1=*/BoardID::COM);
+    int16_t sensor[6];
+    uint64_t timestamp_us;
+} sensor_data_t;
 
-    if (can.begin() == ESP_OK)
+// グローバル変数
+static QueueHandle_t g_sensorQueue = nullptr; // センサー生データ用キュー
+static SPICreate g_spi;                       // SPIクラス
+static ICM g_icm;                             // IMU
+static SdmmcLogger g_sdCard;                  // SDカードロガー
+static GPTimer g_gpt;                         // GPTimer
+
+// ------------------ 目標角(roll, pitch)共有用 ------------------
+static float roll_target = 0.0f;
+static float pitch_target = 0.0f;
+static SemaphoreHandle_t g_angleMutex = nullptr;
+// --------------------------------------------------------------
+
+// 角速度スケーリング係数 (ICM42688 ±2000dps想定)
+static constexpr float GYRO_SCALE_2000DPS = (1.0f / 16.4f) * (3.1415926535f / 180.0f);
+
+// 割り込みコールバック(1kHz)
+static bool IRAM_ATTR sensorTimerCallback(gptimer_handle_t timer,
+                                          const gptimer_alarm_event_data_t *edata,
+                                          void *user_ctx)
+{
+    // IMUからセンサ値を取得
+    sensor_data_t sdata;
+    int16_t sensor[6] = {0};
+    g_icm.Get(sensor);
+
+    for (int i = 0; i < 6; i++)
     {
-        printf("[MAIN] CAN driver started.\n");
+        sdata.sensor[i] = sensor[i];
     }
-    else
+    // タイムスタンプ(μs)
+    sdata.timestamp_us = (uint64_t)esp_timer_get_time();
+
+    // キューへ送る
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    xQueueSendFromISR(g_sensorQueue, &sdata, &xHigherPriorityTaskWoken);
+
+    return (xHigherPriorityTaskWoken == pdTRUE);
+}
+
+// -----------------------------
+// センサー側タスク
+// -----------------------------
+static void sensorTask(void *args)
+{
+    // 1. SPI初期化
+    bool ret = g_spi.begin(
+        SPI2_HOST,
+        (gpio_num_t)6,  // SCLK
+        (gpio_num_t)4,  // MISO
+        (gpio_num_t)5,  // MOSI
+        1 * 1000 * 1000 // 8MHz
+    );
+    if (!ret)
     {
-        printf("[MAIN] can.begin() failed.\n");
+        ESP_LOGE("sensorTask", "SPI begin failed");
+        vTaskDelete(NULL);
         return;
     }
 
-    // 例: 送信 (ContentID=BOARD_STATE)
-    //     => ID= (board=GIMBAL(0b011) <<8 | 0x02(BOARD_STATE)) => 0x302
-    uint8_t data[1] = {0xAA};
-    esp_err_t tx_err = can.send(ContentID::BOARD_STATE, data, 1);
-    if (tx_err == ESP_OK)
+    // 2. ICM42688初期化
+    g_icm.begin(&g_spi, (gpio_num_t)40, 8 * 1000 * 1000);
+
+    // 3. キュー作成
+    g_sensorQueue = xQueueCreate(512, sizeof(sensor_data_t));
+    if (!g_sensorQueue)
     {
-        printf("[MAIN] Tx success.\n");
-    }
-    else
-    {
-        printf("[MAIN] Tx failed.\n");
+        ESP_LOGE("sensorTask", "Failed to create sensor queue");
+        vTaskDelete(NULL);
+        return;
     }
 
-    // 例: イベントドリブンで受信
+    // 4. GPTimer初期化 (1MHz, アラーム=1000 → 1kHz)
+    if (!g_gpt.init(TIMER_RESOLUTION_HZ, TIMER_ALARM_COUNT))
+    {
+        ESP_LOGE("sensorTask", "Failed to init GPTimer");
+        vTaskDelete(NULL);
+        return;
+    }
+    if (!g_gpt.registerCallback(sensorTimerCallback))
+    {
+        ESP_LOGE("sensorTask", "Failed to register GPTimer callback");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    // 5. タイマー開始
+    if (!g_gpt.start())
+    {
+        ESP_LOGE("sensorTask", "Failed to start GPTimer");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    ESP_LOGI("sensorTask", "Sensor reading started (1kHz by GPTimer)");
+
+    // タスクループ
     while (true)
     {
-        // アラート待ち
-        uint32_t alerts = 0;
-        esp_err_t err = twai_read_alerts(&alerts, portMAX_DELAY); // rx_dataが到着するまで他のタスクを実行
-        if (err == ESP_OK)
+        vTaskDelay(pdMS_TO_TICKS(1000));
+        ESP_LOGD("sensorTask", "Sensor task alive...");
+    }
+
+    vTaskDelete(NULL);
+}
+
+// -----------------------------
+// ロギングタスク
+// -----------------------------
+static void loggingTask(void *args)
+{
+    // 1. SDカード初期化
+    bool useHighSpeed = false;
+    if (!g_sdCard.begin(useHighSpeed, "/sdcard", "/sdcard/gyro_log.csv"))
+    {
+        ESP_LOGE("loggingTask", "Failed to mount or open log file.");
+        vTaskDelete(NULL);
+        return;
+    }
+    ESP_LOGI("loggingTask", "SD card initialized");
+
+    // 2. クォータニオン (サンプリング周期=1kHz → 0.001f)
+    SimpleQuat quat(GYRO_SCALE_2000DPS, 0.001f);
+
+    // -----------------------------
+    // 2-1. ジャイロバイアス補正 (60秒)
+    // -----------------------------
+    ESP_LOGI("loggingTask", "Start gyro bias calibration for 60sec...");
+    const int sample_count = 1000 * 5;
+    float sumX = 0.0f, sumY = 0.0f, sumZ = 0.0f;
+    int countSample = 0;
+
+    for (int i = 0; i < sample_count; i++)
+    {
+        sensor_data_t data;
+        if (xQueueReceive(g_sensorQueue, &data, portMAX_DELAY) == pdTRUE)
         {
-            if (alerts & TWAI_ALERT_RX_DATA)
+            sumX += data.sensor[3];
+            sumY += data.sensor[4];
+            sumZ += data.sensor[5];
+            countSample++;
+        }
+    }
+
+    float offsetX = (countSample > 0) ? (sumX / countSample) : 0.0f;
+    float offsetY = (countSample > 0) ? (sumY / countSample) : 0.0f;
+    float offsetZ = (countSample > 0) ? (sumZ / countSample) : 0.0f;
+    quat.setGyroBias(offsetX, offsetY, offsetZ);
+
+    ESP_LOGI("loggingTask", "Calibration done! Gyro bias = (%.2f, %.2f, %.2f)",
+             offsetX, offsetY, offsetZ);
+
+    // -----------------------------
+    // 2-2. 通常ロギング
+    // -----------------------------
+    uint32_t printcount = 0;
+    while (true)
+    {
+        sensor_data_t recvData;
+        if (xQueueReceive(g_sensorQueue, &recvData, portMAX_DELAY) == pdTRUE)
+        {
+            // クォータニオン更新
+            quat.updateFromRawGyro(&recvData.sensor[3]);
+
+            // オイラー角(rad) → deg
+            float euler[3];
+            quat.getEulerRad(euler);
+            float roll_deg = euler[0] * (180.0f / 3.1415926535f);
+            float pitch_deg = euler[1] * (180.0f / 3.1415926535f);
+            float yaw_deg = euler[2] * (180.0f / 3.1415926535f);
+
+            // -----------------------------
+            // ロール・ピッチを「目標角」として共有
+            // -----------------------------
+            if (g_angleMutex && xSemaphoreTake(g_angleMutex, 0) == pdTRUE)
             {
-                // RXキューに何か到着
-                while (true)
-                {
-                    CanRxFrame rx;
-                    esp_err_t e = can.readFrameNoWait(rx);
-                    if (e == ESP_OK)
-                    {
-                        // 受信成功
-                        printf("[MAIN] Rx from Board=%d, Content=0x%02X, dlc=%d\n",
-                               (int)rx.sender_board_id,
-                               (int)rx.content_id,
-                               rx.dlc);
-                    }
-                    else if (e == ESP_ERR_TIMEOUT)
-                    {
-                        // キュー空
-                        break;
-                    }
-                    else
-                    {
-                        // None
-                        break;
-                    }
-                }
+                roll_target = yaw_deg;
+                pitch_target = pitch_deg;
+                xSemaphoreGive(g_angleMutex);
             }
 
-            if (alerts & TWAI_ALERT_BUS_OFF)
+            // ログ書き込み
+            g_sdCard.writeLog(
+                recvData.timestamp_us,
+                recvData.sensor[3],
+                recvData.sensor[4],
+                recvData.sensor[5],
+                roll_deg, pitch_deg, yaw_deg);
+
+            // 100回に1回コンソールへ出力
+            if (printcount++ == 100)
             {
-                // バスオフ検知 → リカバリ
-                printf("[MAIN] BUS_OFF -> attempt recover.\n");
-                can.recover();
-            }
-            if (alerts & TWAI_ALERT_BUS_RECOVERED)
-            {
-                printf("[MAIN] BUS recovered.\n");
+                g_sdCard.flush();
+                ESP_LOGI("loggingTask", "[%.2f ms] GYRO=(%d,%d,%d), EULER=(%.2f, %.2f, %.2f)",
+                         recvData.timestamp_us / 1000.0,
+                         recvData.sensor[3], recvData.sensor[4], recvData.sensor[5],
+                         roll_deg, pitch_deg, yaw_deg);
+                printcount = 0;
             }
         }
-        else
+    }
+
+    vTaskDelete(NULL);
+}
+
+// -----------------------------
+// 角度制御タスク (モータ2ch)
+// -----------------------------
+#define USING_MCPWM
+static void angleControlTask(void *args)
+{
+    // 1. ドライバ初期化 & モータ設定
+    driver1.voltage_power_supply = 12;
+    driver1.voltage_limit = 6;
+#ifdef USING_MCPWM
+    driver1.init(0); // MCPWMユニット0
+
+#else
+    driver1.init({1, 2, 3});
+#endif
+    motor1.linkDriver(&driver1);
+    motor1.controller = MotionControlType::openloop_angle;
+    motor1.velocity_limit = 100.0; // [rad/s]上限
+    motor1.voltage_limit = 6.0;
+    motor1.init();
+
+    driver2.voltage_power_supply = 12;
+    driver2.voltage_limit = 6;
+#ifdef USING_MCPWM
+    driver2.init(1); // MCPWMユニット1
+#else
+    driver2.init({4, 5, 6});
+#endif
+    motor2.linkDriver(&driver2);
+    motor2.controller = MotionControlType::openloop_angle;
+    motor2.velocity_limit = 100.0;
+    motor2.voltage_limit = 6.0;
+    motor2.init();
+
+    ESP_LOGI("angleControlTask", "Motors initialized (open-loop angle).");
+
+    while (true)
+    {
+        float local_roll = 0.0f;
+        float local_pitch = 0.0f;
+
+        // ミューテックスで共有データを取得
+        if (g_angleMutex && xSemaphoreTake(g_angleMutex, pdMS_TO_TICKS(1)) == pdTRUE)
         {
-            // None
+            local_roll = roll_target;
+            local_pitch = pitch_target;
+            xSemaphoreGive(g_angleMutex);
         }
+
+        // deg→rad
+        float target_angle1 = local_roll * 3.1415926535f / 180.0f;
+        float target_angle2 = local_pitch * 3.1415926535f / 180.0f;
+
+        // モータ1,2 それぞれ角度指令を与える（オープンループ）
+        motor1.move(target_angle1);
+        motor2.move(target_angle2);
+
+        // ループ周期 (約1kHz)
+        vTaskDelay(1);
+    }
+
+    vTaskDelete(NULL);
+}
+
+// -----------------------------
+// メイン (タスク生成)
+// -----------------------------
+extern "C" void app_main(void)
+{
+    // 目標角共有用ミューテックス
+    g_angleMutex = xSemaphoreCreateMutex();
+
+    // 各タスクをコア分離
+    xTaskCreatePinnedToCore(sensorTask, "sensorTask", 4096, NULL, 5, NULL, 1);
+    xTaskCreatePinnedToCore(loggingTask, "loggingTask", 8192, NULL, 5, NULL, 1);
+
+    // 角度制御タスクは別コアへ
+    xTaskCreatePinnedToCore(angleControlTask, "angleControlTask", 8192, NULL, 6, NULL, 0);
+
+    // メインタスクは何もしない
+    while (true)
+    {
+        vTaskDelay(pdMS_TO_TICKS(1000));
     }
 }

--- a/main/foc/example/velocity-openloop.cpp
+++ b/main/foc/example/velocity-openloop.cpp
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <string>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_simplefoc.h"
+
+#if CONFIG_SOC_MCPWM_SUPPORTED
+#define USING_MCPWM
+#endif
+
+BLDCMotor motor = BLDCMotor(1);
+BLDCDriver3PWM driver = BLDCDriver3PWM(38, 45, 48);
+
+BLDCMotor motor2 = BLDCMotor(2);
+BLDCDriver3PWM driver2 = BLDCDriver3PWM(10, 11, 12);
+
+extern "C" void app_main(void)
+{
+    SimpleFOCDebug::enable(); /*!< Enable Debug */
+    Serial.begin(115200);
+
+    driver.voltage_power_supply = 12;
+    driver.voltage_limit = 11;
+
+    driver2.voltage_power_supply = 12;
+    driver2.voltage_limit = 11;
+
+#ifdef USING_MCPWM
+    driver.init(0);
+    driver2.init(1);
+
+#else
+    driver.init({1, 2, 3});
+    driver2.init({4, 5, 6});
+#endif
+    motor.linkDriver(&driver);
+    motor2.linkDriver(&driver2);
+
+    motor.velocity_limit = 200.0;
+    motor.voltage_limit = 12.0;
+    motor.controller = MotionControlType::velocity_openloop;
+
+    motor2.velocity_limit = 200.0;
+    motor2.voltage_limit = 12.0;
+    motor2.controller = MotionControlType::velocity_openloop;
+
+    motor.init();
+    motor2.init();
+
+    float speed = 0;
+    int count = 0;
+
+    while (1)
+    {
+        motor.move(speed);
+        motor2.move(speed);
+
+        count++;
+        if (count > 100)
+        {
+            speed++;
+            count = 0;
+        }
+
+        vTaskDelay(1 / portTICK_PERIOD_MS);
+    }
+}


### PR DESCRIPTION
CANも追加
オープンループでロールピッチ制御追加済み
以下自動生成
This pull request includes several changes to enhance the functionality and structure of the CAN communication system, SPI device handling, and the main application logic. The most significant changes include the addition of new CAN communication classes, updates to SPI device limits, and the integration of SimpleFOC for motor control.

### CAN Communication Enhancements:

* [`main/CAN/73CanConfig.hpp`](diffhunk://#diff-25f0ec45369843e3c7971b3b5d18e22cf1a3ac27e68e4de537a3b272e0e73f5dR1-R64): Added new enumerations for `BoardID`, `ContentID`, and commands for mode transitions, servo operations, and status notifications. Introduced `CanRxFrame` struct for receiving data.
* [`main/CAN/CanComm.cpp`](diffhunk://#diff-e1238518b4097497080192e44918abf4c9780e213afc061312d0cfe345c612c5R1-R224): Implemented the `CanComm` class with methods for CAN ID conversion, driver initialization, data transmission, and reception.
* [`main/CAN/CanComm.hpp`](diffhunk://#diff-30475f775ff72861e774fd2b93b9df8198d8421fc08885ec6c575cabb70d0b90R1-R87): Declared the `CanComm` class with detailed documentation on its usage and functionalities.
* [`main/CAN/example/main.cpp`](diffhunk://#diff-e324deb0fe29acacd66b5764f6ebb4b73677de414b7bbbaa9a2046a1a8f89edaR1-R95): Provided an example of using the `CanComm` class, demonstrating initialization, sending, and receiving CAN messages.

### SPI Device Handling:

* [`main/SPICREATE/SPICREATE.cpp`](diffhunk://#diff-5111fc3c36611b122e39ad86550e610c5bccbc878a337201a214b17ffa5e8525L46-R46): Increased the maximum number of SPI devices from 3 to 4 to accommodate additional peripherals.
* [`main/SPICREATE/SPICREATE.hpp`](diffhunk://#diff-c82b97e0bc240742406c5989e65f2d05de7dbb2c985c2a1b9f876b4e5f22bc88L14-R14): Updated the `SPICreate` class to handle up to 4 SPI devices.

### Main Application Enhancements:

* [`main/app_main.cpp`](diffhunk://#diff-c70685b72e933396e5d74f409086b61f453876d48574b717e879bb99ba63154cL13-R32): Integrated SimpleFOC for motor control, defining two BLDC motors and their respective drivers.

### Build System Updates:

* [`main/CMakeLists.txt`](diffhunk://#diff-e1bc61f89706898f754134386b0c25982fa6dd53e2c7172f66d36a9f6b773dc5R6-R14): Included `CAN/CanComm.cpp` in the build system and added the `CAN` directory to the include paths.
